### PR TITLE
GetInUsePackages.linq: Fix obsolete property use

### DIFF
--- a/Octopus.Client/LINQPad/GetInUsePackages.linq
+++ b/Octopus.Client/LINQPad/GetInUsePackages.linq
@@ -24,7 +24,7 @@ var inUsePackagesQ = from release in releases
 					 let action = processes[release.ProjectDeploymentProcessSnapshotId]
 										 .Steps
 										 .SelectMany(s => s.Actions)
-										 .First(s => s.Name == selectedPackage.StepName)
+										 .First(s => s.Name == selectedPackage.ActionName)
 					 select new
 					{
 						Feed = feeds[action.Properties["Octopus.Action.Package.FeedId"].Value],


### PR DESCRIPTION
Fixed errors/unexpected results due to use of obsolete use of property `SelectedPackage.StepName` by replacing it with `SelectedPackage.ActionName`. Ref: https://github.com/OctopusDeploy/OctopusClients/commit/836ac2a57068ea21f878e9ff2f1a88267760509b#diff-5ab356e281871b6fb3c5015ff63e4191