### PR TITLE
Update CreateRelease.ps1

### DIFF
--- a/REST/PowerShell/Releases/CreateRelease.ps1
+++ b/REST/PowerShell/Releases/CreateRelease.ps1
@@ -43,7 +43,7 @@ try
     }
 
     # Create release
-    $releaseBody = $releaseBody | ConvertTo-Json
+    $releaseBody = $releaseBody | ConvertTo-Json -depth 10
     Write-Host "Creating release with these values: $releaseBody"
     $release = Invoke-WebRequest -Uri "$octopusURL/api/$($space.id)/releases" -Method POST -Headers $header -Body $releaseBody -ErrorVariable octoError | ConvertFrom-Json
 }

--- a/REST/PowerShell/Releases/CreateRelease.ps1
+++ b/REST/PowerShell/Releases/CreateRelease.ps1
@@ -3,7 +3,6 @@ $octopusURL = "https://youroctourl"
 $octopusAPIKey = "API-YOURAPIKEY"
 $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 $projectName = "MyProject"
-$releaseVersion = "1.0.0.0"
 $channelName = "Default"
 $spaceName = "default"
 
@@ -22,42 +21,31 @@ try
     $channel = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/channels" -Headers $header).Items | Where-Object {$_.Name -eq $channelName}
 
     # Loop through the deployment process and gather selected packages
-    $selectedPackages = @()
-    foreach ($step in $deploymentProcess.Steps)
-    {
-        # Loop through the actions
-        foreach($action in $step.Actions)
-        {
-            # Check for packages
-            if ($null -ne $action.Packages)
-            {
-                # Loop through packages
-                foreach ($package in $action.Packages)
-                {
-                    # Get latest version of package
-                    $packageVersion = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/feeds/$($package.FeedId)/packages/versions?packageId=$($package.PackageId)&take=1" -Headers $header).Items[0].Version
+    $releaseBody = @{
+        ChannelId        = $channel.Id
+        ProjectId        = $project.Id
+        Version          = $template.NextVersionIncrement
+        SelectedPackages = @()
+    }
+    $template = Invoke-WebRequest -Uri "$octopusURL/api/$($space.id)/deploymentprocesses/deploymentprocess-$($project.id)/template?channel=$($channel.Id)" -Headers $header | ConvertFrom-Json
 
-                    # Add package to selected packages
-                    $selectedPackages += @{
-                        ActionName = $action.Name
-                        Version = $packageVersion
-                        PackageReferenceName = $package.PackageId
-                    }
-                }
-            }
+    Write-Host "Getting step package versions"
+    $template.Packages | ForEach-Object {
+        $uri = "$octopusURL/api/$($space.id)/feeds/$($_.FeedId)/packages/versions?packageId=$($_.PackageId)&take=1"
+        $version = Invoke-WebRequest -Uri $uri -Method GET -Headers $header -Body $releaseBody -ErrorVariable octoError | ConvertFrom-Json
+        $version = $version.Items[0].Version
+
+        $releaseBody.SelectedPackages += @{
+            ActionName           = $_.ActionName
+            PackageReferenceName = $_.PackageReferenceName
+            Version              = $version
         }
     }
 
-    # Create json payload
-    $jsonPayload = @{
-        ProjectId = $project.Id
-        ChannelId = $channel.Id
-        Version = $releaseVersion
-        SelectedPackages = $selectedPackages
-    }
-
-    # Create the release
-    Invoke-RestMethod -Method Post -Uri "$octopusURL/api/$($space.Id)/releases" -Body ($jsonPayload | ConvertTo-Json -Depth 10) -Headers $header
+    # Create release
+    $releaseBody = $releaseBody | ConvertTo-Json
+    Write-Host "Creating release with these values: $releaseBody"
+    $release = Invoke-WebRequest -Uri "$octopusURL/api/$($space.id)/releases" -Method POST -Headers $header -Body $releaseBody -ErrorVariable octoError | ConvertFrom-Json
 }
 catch
 {


### PR DESCRIPTION
Deploy Package steps need the packagereferencename to be blank, the way it was written here will always pull the package id which will break deploy package steps. This instead looks at the deployment process and pulls in the information it needs and allows you to add any logic necessary for versioning.

This also changes it so the version of the release is the next increment, but I'm not sure if you want to keep that.