### PR TITLE
Script to retrieve the latest deployment info for every deployment target

### DIFF
--- a/REST/PowerShell/Targets/Get-RecentDeploymentsForMachines.ps1
+++ b/REST/PowerShell/Targets/Get-RecentDeploymentsForMachines.ps1
@@ -1,0 +1,21 @@
+# Define Octopus variables
+$octopusURL = "https://youroctopusserver"
+$octopusAPIKey = "API-KEY"
+$header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
+$spaceName = "Default"
+
+# Get space
+$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}
+
+# Get machine details
+$machines = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines" -Headers $header).Items
+
+foreach ($machine in $machines) {
+    $machineTasks = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines/$($machine.Id)/tasks" -Headers $header).Items
+    if ($machineTasks.Count -gt 0) {
+        $machine | Add-Member LastDeployment $machineTasks[0].Description
+        $machine | Add-Member LastDeploymentQueueTime $machineTasks[0].QueueTime
+    }
+}
+
+$machines | Select-Object Id, Name, Status, LastDeployment, LastDeploymentQueueTime | Format-Table


### PR DESCRIPTION
Example output:
```pwsh
Id            Name                              Status   LastDeployment                                          LastDeploymentQueueTime
--            ----                              ------   --------------                                          -----------------------
Machines-4038 d-Samples-MySQL-K8                Online   Deploy MySQL Helm Chart release 2020.1.3 to Development 10/14/2020 11:40:03 AM
Machines-2675 d-Samples-OctoPetShop-K8          Online   Deploy Octo Pet Shop release 2020.1.10 to Development   9/16/2020 1:32:07 PM
Machines-938  FE506043F8AC                      Offline
Machines-573  OctoPetShop Development Namespace Online   Deploy Web App release 2020.10.07.1 to Development      10/7/2020 2:44:04 PM
Machines-581  OctoPetShop Production Namespace  Online   Deploy Web App release 2020.08.10.0 to Production       8/10/2020 1:08:24 PM
Machines-582  OctoPetShop Test Namespace        Online   Deploy Web App release 2020.08.10.0 to Test             8/10/2020 12:36:42 PM
Machines-492  OpenShift-dev                     Disabled
Machines-715  p-Samples-MySQL-K8                Online   Deploy MySQL Helm Chart release 2020.1.3 to Production  10/14/2020 12:28:19 PM
Machines-2674 p-Samples-OctoPetShop-K8          Online   Deploy Octo Pet Shop release 2020.1.8 to Production     8/10/2020 11:47:48 AM
Machines-4370 samples-octopus-Development       Online
Machines-615  TeamCity Production Namespace     Online   Deploy TeamCity release 2019.2.4 to Production          4/14/2020 11:23:07 AM
Machines-744  tomcat-petclinic-test-vm          Offline
Machines-4039 t-Samples-MySQL-K8                Online   Deploy MySQL Helm Chart release 2020.1.3 to Test        10/14/2020 11:43:27 AM
Machines-2673 t-Samples-OctoPetShop-K8          Online   Deploy Octo Pet Shop release 2020.1.8 to Test           8/10/2020 11:29:37 AM
```