### PR TITLE
Updated sync script for bento input file

### DIFF
--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -1,3 +1,94 @@
+[CmdletBinding()]
+param (
+    [Parameter()]
+    [ValidateSet("FileVersions", "LatestVersion", "AllVersions")]
+    [string] $VersionSelection = "FileVersions",
+
+    [Parameter()]
+    [string] $Path,
+
+    [Parameter(Mandatory)]
+    [string] $SourceUrl,
+
+    [Parameter(Mandatory)]
+    [string] $SourceApiKey,
+
+    [Parameter()]
+    [string] $SourceSpace = "Default",
+
+    [Parameter(Mandatory)]
+    [string] $DestinationUrl,
+
+    [Parameter(Mandatory)]
+    [string] $DestinationApiKey,
+
+    [Parameter()]
+    [string] $DestionationSpace = "Default",
+
+    [Parameter()]
+    $CutoffDate = $null
+)
+
+function Push-Package([string] $fileName, $package) {
+    Write-Information "Package $fileName does not exist in destination"
+    Write-Verbose "Downloading $fileName..."
+    $download = $sourceHttpClient.GetStreamAsync($sourceOctopusURL + $package.Links.Raw).GetAwaiter().GetResult()
+
+    $contentDispositionHeaderValue = New-Object System.Net.Http.Headers.ContentDispositionHeaderValue "form-data"
+    $contentDispositionHeaderValue.Name = "fileData"
+    $contentDispositionHeaderValue.FileName = $fileName 
+
+    $streamContent = New-Object System.Net.Http.StreamContent $download
+    $streamContent.Headers.ContentDisposition = $contentDispositionHeaderValue
+    $contentType = "multipart/form-data"
+    $streamContent.Headers.ContentType = New-Object System.Net.Http.Headers.MediaTypeHeaderValue $contentType
+
+    $content = New-Object System.Net.Http.MultipartFormDataContent
+    $content.Add($streamContent)
+
+    # Upload package
+    $upload = $destinationHttpClient.PostAsync("$destinationOctopusURL/api/$destinationSpaceId/packages/raw?replace=false", $content)
+        while (-not $upload.AsyncWaitHandle.WaitOne(10000)) {
+        Write-Verbose "Uploading $fileName..."
+    }
+}
+
+function Skip-Package([string] $filename, $package, $cutoffDate) {
+    if ($null -eq $cutoffDate) { 
+        return $false; 
+    }
+
+    if ($package.Published -lt $cutoffDate) {
+        Write-Warning "$filename was published on $($package.Published), which is earlier than the specified cut-off date, and will be skipped"
+        return $true;
+    }
+
+    return $false
+}
+
+function Get-Packages([string] $packageId, [int] $batch, [int] $skip) {
+    Write-Host "batch: $batch"
+    $getPackagesToSyncUrl = "$sourceOctopusURL/api/$sourceSpaceId/packages?nugetPackageId=$($package.Id)&take=$batch&skip=$skip"
+    Write-Host "Fetching packages from $getPackagesToSyncUrl"
+    $packagesResponse = Invoke-RestMethod -Method Get -Uri "$getPackagesToSyncUrl" -Headers $sourceHeader
+    return $packagesResponse;
+}
+
+function Get-PackageExists([string] $filename, $package) {
+    Write-Host "Checking if $fileName exists in destination..."
+    $checkForExistingPackageURL = "$destinationOctopusURL/api/$destinationSpaceId/packages/packages-$($package.Id).$($pkg.Version)" 
+    $checkForExistingPackageResponse =  Invoke-WebRequest -Method Get -Uri $checkForExistingPackageURL -Headers $destinationHeader -SkipHttpErrorCheck 
+    if ($checkForExistingPackageResponse.StatusCode -ne 404) {
+        if ($checkForExistingPackageResponse.StatusCode -eq 200) {
+            Write-Verbose "Package $fileName already exists on the destination. Skipping."
+            return $true;
+        } else {
+            Write-Error "Unexpected status code $($checkForExistingPackageResponse.StatusCode) returned from $checkForExistingPackageURL"
+        }
+    } 
+    return $false;
+}
+
 # This script syncs packages from the built-in feed between two spaces. 
 # The spaces can be on the same Octopus instance, or in different instances
 
@@ -6,23 +97,14 @@ $ErrorActionPreference = "Stop"
 # ******* Variables to be specified before running ********
 
 # Source Octopus instance details and credentials
-$sourceOctopusURL = "https://octopus.acme.com"
-$sourceOctopusAPIKey = "API-XXXXXXXXXXXXXXX"
-$sourceSpaceName = "Default"
+$sourceOctopusURL = $sourceUrl
+$sourceOctopusAPIKey = $sourceApiKey
+$sourceSpaceName = $sourceSpace
 
 # Destination Octopus instance details and credentials
-$destinationOctopusURL = "https://acme.octopus.app"
-$destinationOctopusAPIKey = "API-XXXXXXXXXXXXXXXX"
-$destinationSpaceName = "Acme Online"
-
-# Replace with the packages you wish to sync
-$packageIds = @(
-    #"Acme.Web"
-    #,"Acme.Database"
-) 
-
-# Don't sync packages older than this date 
-$cutoffDate = Get-Date "02/02/2020"
+$destinationOctopusURL = $destinationUrl
+$destinationOctopusAPIKey = $destinationApiKey
+$destinationSpaceName = $destionationSpace
 
 # *****************************************************
 
@@ -45,74 +127,91 @@ $totalSyncedPackageSize = 0
 
 Write-Host "Syncing packages between $sourceOctopusURL and $destinationOctopusURL"
 
+$packages = Get-Content -Path $path | ConvertFrom-Json
+
 # Iterate supplied package IDs
-foreach($packageId in $packageIds) {
-    Write-Host "Syncing $packageId packages (published after $cutoffDate)"
-    $skip=0;
-    $batchSize=100;
+foreach($package in $packages) {
+    Write-Host "Syncing $($package.Id) packages (published after $cutoffDate)"
     $processedPackageCount = 0
-
-    do {
-        $getPackagesToSyncUrl = "$sourceOctopusURL/api/$sourceSpaceId/packages?nugetPackageId=$packageId&take=$batchSize&skip=$skip"
-        Write-Verbose "Fetching packages from $getPackagesToSyncUrl"
-        $packagesResponse = Invoke-RestMethod -Method Get -Uri "$getPackagesToSyncUrl" -Headers $sourceHeader    
-
-        foreach($package in $packagesResponse.Items) {
-            Write-Verbose "Processing $($package.PackageId).$($package.Version)"
-            $fileName = "$($package.PackageId).$($package.Version)$($package.FileExtension)" 
-
-            if ($package.Published -lt $cutoffDate) {
-                Write-Verbose "$fileName was published on $($package.Published), which is earlier than the specified cut-off date, and will be skipped"
-                $processedPackageCount++
-                continue
-            }
-
-           # Write-Verbose "Checking if $fileName exists in destination..."
-            $checkForExistingPackageURL = "$destinationOctopusURL/api/$destinationSpaceId/packages/packages-$packageId.$($package.Version)" 
-            $checkForExistingPackageResponse =  Invoke-WebRequest -Method Get -Uri $checkForExistingPackageURL -Headers $destinationHeader -SkipHttpErrorCheck 
-
-            if ($checkForExistingPackageResponse.StatusCode -ne 404) {
-                if ($checkForExistingPackageResponse.StatusCode -eq 200) {
-                    Write-Verbose "Package $fileName already exists on the destination. Skipping."
-                    $processedPackageCount++
-                    continue
-                } else {
-                    Write-Error "Unexpected status code $($checkForExistingPackageResponse.StatusCode) returned from $checkForExistingPackageURL"
+    $skip=0;
+    $batchSize = 100;
+    
+    if ($VersionSelection -eq 'AllVersions') {
+        do {
+            $packagesResponse = Get-Packages $package.Id $batchSize $skip
+            foreach($pkg in $packagesResponse.Items) {
+                Write-Host "Processing $($pkg.PackageId).$($pkg.Version)"
+                $fileName = "$($pkg.PackageId).$($pkg.Version)$($pkg.FileExtension)"
+                
+                if (-not (Skip-Package $fileName $pkg $CutoffDate)) {
+                    if (Get-PackageExists $fileName $package) {
+                        $processedPackageCount++
+                        continue;
+                    } else {
+                        Push-Package $fileName $pkg
+                        $processedPackageCount++ 
+                        $totalSyncedPackageCount++ 
+                        $totalSyncedPackageSize += $pkg.PackageSizeBytes
+                    }
                 }
-            } else {
-                Write-Verbose "Package does not exist in destination"
+                else {
+                    $processedPackageCount++
+                }
             }
 
-            Write-Verbose "Downloading $fileName..."
-            $download = $sourceHttpClient.GetStreamAsync($sourceOctopusURL + $package.Links.Raw).GetAwaiter().GetResult()
-
-            $contentDispositionHeaderValue = New-Object System.Net.Http.Headers.ContentDispositionHeaderValue "form-data"
-            $contentDispositionHeaderValue.Name = "fileData"
-            $contentDispositionHeaderValue.FileName = $fileName 
-
-            $streamContent = New-Object System.Net.Http.StreamContent $download
-            $streamContent.Headers.ContentDisposition = $contentDispositionHeaderValue
-            $contentType = "multipart/form-data"
-            $streamContent.Headers.ContentType = New-Object System.Net.Http.Headers.MediaTypeHeaderValue $contentType
-
-            $content = New-Object System.Net.Http.MultipartFormDataContent
-            $content.Add($streamContent)
-
-            # Upload package
-            $upload = $destinationHttpClient.PostAsync("$destinationOctopusURL/api/$destinationSpaceId/packages/raw?replace=false", $content)
-             while (-not $upload.AsyncWaitHandle.WaitOne(10000)) {
-                Write-Verbose "Uploading $fileName..."
-            }
-            
-            $processedPackageCount++ 
-            $totalSyncedPackageCount++ 
-            $totalSyncedPackageSize += $package.PackageSizeBytes
-
-            Write-Host "$fileName sync complete. $processedPackageCount/$($packagesResponse.TotalResults)"
+            $skip = $skip + $packagesResponse.Items.Count
+        } while ($packagesResponse.Items.Count -eq $batchSize)
+    }
+    elseif ($VersionSelection -eq 'LatestVersion') {
+        $packagesResponse = Get-Packages $package.Id 1 0
+        $pkg = $packagesResponse.Items | Select-Object -First 1
+        if ($null -ne $pkg) {
+            $fileName = "$($pkg.PackageId).$($pkg.Version)$($pkg.FileExtension)"
+            if (-not (Skip-Package $fileName $pkg $CutOffDate)) {
+                if (Get-PackageExists $fileName $package) {
+                    $processedPackageCount++
+                    continue;
+                } else {
+                    Push-Package $fileName $pkg
+                    $processedPackageCount++ 
+                    $totalSyncedPackageCount++ 
+                    $totalSyncedPackageSize += $pkg.PackageSizeBytes
+                }
+            }    
         }
+    }
+    elseif ($VersionSelection -eq "FileVersions") {
+        $versions = $package.Versions;
+        $packagesResponse = Get-Packages $package.Id $batchSize $skip
+        
+        do {
+            foreach ($pkg in $packagesResponse.Items) {
+                if ($versions.Contains($pkg.Version)) {
+                    Write-Host "Processing $($pkg.PackageId).$($pkg.Version)"
+                    $fileName = "$($pkg.PackageId).$($pkg.Version)$($pkg.FileExtension)"
 
-        $skip = $skip + $packagesResponse.Items.Count
-    } while ($packagesResponse.Items.Count -eq $batchSize) 
+                    if (-not (Skip-Package $fileName $pkg $CutoffDate)) {
+                        if (Get-PackageExists $fileName $package) {
+                            $processedPackageCount++
+                            continue;
+                        } else {
+                            Push-Package $fileName $pkg
+                            $processedPackageCount++ 
+                            $totalSyncedPackageCount++ 
+                            $totalSyncedPackageSize += $pkg.PackageSizeBytes
+                        }
+                    }
+                    else {
+                        $processedPackageCount++
+                    }
+                }
+            }
+
+            $skip = $skip + $packagesResponse.Items.Count
+        } while ($packagesResponse.Items.Count -eq $batchSize)
+    }
+
+    Write-Host "$fileName sync complete. $processedPackageCount/$($packagesResponse.TotalResults)"
 }
 
-Write-Host "Sync complete.  $totalSyncedPackageCount packages ($($totalSyncedPackageSize/1MB) megabytes) were copied." -ForegroundColor Green
+Write-Host "Sync complete.  $totalSyncedPackageCount packages ($("{0:n2}" -f ($totalSyncedPackageSize/1MB)) megabytes) were copied." -ForegroundColor Green

--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -67,7 +67,6 @@ function Skip-Package([string] $filename, $package, $cutoffDate) {
 }
 
 function Get-Packages([string] $packageId, [int] $batch, [int] $skip) {
-    Write-Host "batch: $batch"
     $getPackagesToSyncUrl = "$sourceOctopusURL/api/$sourceSpaceId/packages?nugetPackageId=$($package.Id)&take=$batch&skip=$skip"
     Write-Host "Fetching packages from $getPackagesToSyncUrl"
     $packagesResponse = Invoke-RestMethod -Method Get -Uri "$getPackagesToSyncUrl" -Headers $sourceHeader

--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -23,7 +23,7 @@ param (
     [string] $DestinationApiKey,
 
     [Parameter()]
-    [string] $DestionationSpace = "Default",
+    [string] $DestinationSpace = "Default",
 
     [Parameter()]
     $CutoffDate = $null
@@ -103,7 +103,7 @@ $sourceSpaceName = $sourceSpace
 # Destination Octopus instance details and credentials
 $destinationOctopusURL = $destinationUrl
 $destinationOctopusAPIKey = $destinationApiKey
-$destinationSpaceName = $destionationSpace
+$destinationSpaceName = $destinationSpace
 
 # *****************************************************
 


### PR DESCRIPTION
This adds support for using the Bento package file for syncing packages between two instances.

All input is now moved to script parameters.

`./SyncPackages.ps1 -VersionSelection AllVersions -Path "packages.json" -SourceUrl http://localhost:8065 -SourceApiKey API-5678 -SourceSpace "Default" -DestinationUrl https://destination.octopus.app -DestinationApiKey API-1234 -DestionationSpace "Default" -CutOffDate 02/11/2021`

File input format is:
```
[
  {
    "Id": "TestWebApp",
    "Versions": [
      "1.0.0",
      "1.0.1"
    ]
  },
  {
    "Id": "TestWebApp2",
    "Versions": [
      "1.0.0",
      "1.0.2"
    ]
  }
]
```

Supported `VersionSelection` options:
`FileVersions`: will only process the version numbers in the input file. Versions not found in the source server are skipped.
`AllVersions`: will sync all versions of the supplied Package Ids 
`LatestVersion`: will sync the latest version of each supplied Package Id

`CutOffDate` will skip over any packages found in the source earlier than this date.