### PR TITLE
Extend package push timeout beyond the default 100 secs

### DIFF
--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -5,7 +5,7 @@ param (
     [string] $VersionSelection = "FileVersions",
 
     [Parameter()]
-    [string] $Path,
+    [string] $PackageListFilePath,
 
     [Parameter(Mandatory)]
     [string] $SourceUrl,
@@ -131,7 +131,7 @@ $totalSyncedPackageSize = 0
 
 Write-Host "Syncing packages between $sourceOctopusURL and $destinationOctopusURL"
 
-$packages = Get-Content -Path $path | ConvertFrom-Json
+$packages = Get-Content -Path $PackageListFilePath | ConvertFrom-Json
 
 # Iterate supplied package IDs
 foreach($package in $packages) {

--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -117,13 +117,14 @@ $destinationHeader = @{ "X-Octopus-ApiKey" = $destinationOctopusAPIKey }
 $destinationSpaceId = ((Invoke-RestMethod -Method Get -Uri "$destinationOctopusURL/api/spaces/all" -Headers $destinationHeader) | Where-Object {$_.Name -eq $destinationSpaceName}).Id
 
 # Create HTTP clients 
+$httpClientTimeoutInMinutes = 60
 $sourceHttpClient = New-Object System.Net.Http.HttpClient
 $sourceHttpClient.DefaultRequestHeaders.Add("X-Octopus-ApiKey", $sourceOctopusAPIKey)
-$sourceHttpClient.Timeout = New-TimeSpan -Minutes 60
+$sourceHttpClient.Timeout = New-TimeSpan -Minutes $httpClientTimeoutInMinutes
 
 $destinationHttpClient = New-Object System.Net.Http.HttpClient
 $destinationHttpClient.DefaultRequestHeaders.Add("X-Octopus-ApiKey", $destinationOctopusAPIKey)
-$destinationHttpClient.Timeout = New-TimeSpan -Minutes 60
+$destinationHttpClient.Timeout = New-TimeSpan -Minutes $httpClientTimeoutInMinutes
 
 $totalSyncedPackageCount = 0
 $totalSyncedPackageSize = 0

--- a/REST/PowerShell/Feeds/SyncPackages.ps1
+++ b/REST/PowerShell/Feeds/SyncPackages.ps1
@@ -119,9 +119,11 @@ $destinationSpaceId = ((Invoke-RestMethod -Method Get -Uri "$destinationOctopusU
 # Create HTTP clients 
 $sourceHttpClient = New-Object System.Net.Http.HttpClient
 $sourceHttpClient.DefaultRequestHeaders.Add("X-Octopus-ApiKey", $sourceOctopusAPIKey)
+$sourceHttpClient.Timeout = New-TimeSpan -Minutes 60
 
 $destinationHttpClient = New-Object System.Net.Http.HttpClient
 $destinationHttpClient.DefaultRequestHeaders.Add("X-Octopus-ApiKey", $destinationOctopusAPIKey)
+$destinationHttpClient.Timeout = New-TimeSpan -Minutes 60
 
 $totalSyncedPackageCount = 0
 $totalSyncedPackageSize = 0


### PR DESCRIPTION
The default client timeout is 100secs, which isn't enough for large packages. I've set this to be an hour