### PR TITLE
Script to initialize custom step template parameter Control Types to Single Line Text

### DIFF
--- a/REST/PowerShell/StepTemplates/Initialize-StepTemplateControlTypes.ps1
+++ b/REST/PowerShell/StepTemplates/Initialize-StepTemplateControlTypes.ps1
@@ -1,0 +1,33 @@
+$ErrorActionPreference = 'Stop';
+
+# Define working variables
+$octopusURL = "https://your.octopus.server"
+$octopusAPIKey = "API-KEY"
+
+function Invoke-PagedOctoGet($uriFragment)
+{
+    $items = @()
+    $response = $null
+    do {
+        $uri = if ($response) { $octopusURL + $response.Links.'Page.Next' } else { "$octopusURL/$uriFragment" }
+        $response = Invoke-RestMethod -Method Get -Uri $uri -Headers @{ "X-Octopus-ApiKey" = $octopusAPIKey }
+        $items += $response.Items
+    } while ($response.Links.'Page.Next')
+
+    $items
+}
+
+$stepTemplates = Invoke-PagedOctoGet "api/actiontemplates" | Where-Object { $_.CommunityActionTemplateId -eq $null }
+foreach ($stepTemplate in $stepTemplates) {
+    foreach ($parameter in $stepTemplate.Parameters) {
+        if (!($parameter.DisplaySettings.PSObject.Properties.Name -match "Octopus.ControlType")) {
+            $parameter.DisplaySettings = @{'Octopus.ControlType' = 'SingleLineText'}
+
+            Invoke-RestMethod `
+                -Method Put `
+                -Uri "$octopusURL/api/actiontemplates/$($stepTemplate.Id)" `
+                -Headers @{ "X-Octopus-ApiKey" = $octopusAPIKey } `
+                -Body ($stepTemplate | ConvertTo-Json -Depth 5)
+        }
+    }
+}


### PR DESCRIPTION
The context for this is here:
https://github.com/OctopusDeploy/Issues/issues/6739

Another customer recently reported this issue again, and so as a stop gap this script will search for all custom step templates without any control type specified and it will update those templates to set the control type to a Single Line Text box.