### PR TITLE
Fixed nested property reference

### DIFF
--- a/Octopus.Client/PowerShell/StepTemplates/UpdateInDeploymentProcesses.ps1
+++ b/Octopus.Client/PowerShell/StepTemplates/UpdateInDeploymentProcesses.ps1
@@ -85,7 +85,7 @@ Function Update-StepTemplatesOnDeploymentProcesses
                     $process = $repository.DeploymentProcesses.Get($d.DeploymentProcessId)
 
                     #Finding the step that uses the step template
-                    $steps = $process.Steps | ?{$_.actions.properties.values -eq $template.Id}
+                    $steps = $process.Steps | ?{$_.actions.properties.values.value -eq $template.Id}
 
                     try{
 


### PR DESCRIPTION
* Fixed nested step property reference to correctly evaluate steps for template updates. 
* Tested locally, able to update step template references
* No other references to `actions.properties.values` found in other repo scripts.