### PR TITLE
Fixing scoping bug.

### DIFF
--- a/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
+++ b/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
@@ -9,9 +9,6 @@ function Set-OctopusVariable {
         $varValue = ""                            # Replace with the value of the variable
     )
 
-    # The code for this function was mostly copied from: 
-    # https://github.com/OctopusDeploy/OctopusDeploy-Api/blob/master/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
-
     # Defines header for API call
     $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 

--- a/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
+++ b/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
@@ -1,63 +1,77 @@
-$ErrorActionPreference = "Stop";
+function Set-OctopusVariable {
+    param(
+        $octopusURL = "https://xxx.octopus.app/", # Octopus Server URL
+        $octopusAPIKey = "API-xxx",               # API key goes here
+        $projectName = "xxx",                     # Replace with your project name
+        $spaceName = "Default",                   # Replace with the name of the space you are working in
+        $environment = $null,                     # Replace with the name of the environment you want to scope the variables to
+        $varName = "",                            # Replace with the name of the variable
+        $varValue = ""                            # Replace with the value of the variable
+    )
 
-# Define working variables
-$octopusURL = "https://OctopusServerURL" # Octopus Server URL
-$octopusAPIKey = "API-XXXXXXXXXXXXXXXXXXXXXXXXXX" # API key goes here
-$projectName = "ProjectName" # Replace with your project name
-$spaceName = "Default" # Replace with the name of the space you are working in
-$environment = "DevEnv" # Replace with the name of the environment you want to scope the variables to
+    # Defines header for API call
+    $header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
 
-# Defines header for API call
-$header = @{ "X-Octopus-ApiKey" = $octopusAPIKey }
+    # Get space
+    $space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}
 
-# Get space
-$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}
+    # Get project
+    $project = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/projects/all" -Headers $header) | Where-Object {$_.Name -eq $projectName}
 
-# Get project
-$project = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/projects/all" -Headers $header) | Where-Object {$_.Name -eq $projectName}
+    # Get project variables
+    $projectVariables = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header
 
-# Get project variables
-$projectVariables = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header
+    # Get environment to scope to
+    $environmentObj = $projectVariables.ScopeValues.Environments | Where { $_.Name -eq $environment } | Select -First 1
 
-# Get environment to scope to
-$environmentObj = $projectVariables.ScopeValues.Environments | Where { $_.Name -eq $environment } | Select -First 1
-
-# Define values for variable
-$variable = @{
-    Name = "VariableName" # Replace with a variable name
-    Value = "123456" # Replace with a value
-    Type = "String"
-    IsSensitive = $false
-    Scope = @{ 
+    # Define values for variable
+    $variable = @{
+        Name = $varName  # Replace with a variable name
+        Value = $varValue # Replace with a value
+        Type = "String"
+        IsSensitive = $false
+        Scope = @{ 
             Environment = @(
                 $environmentObj.Id
                 )
             }
+    }
+
+    # Check to see if variable is already present
+    $variablesWithSameName = $projectVariables.Variables | Where-Object {$_.Name -eq $variable.Name}
+
+    if (@($variablesWithSameName.Name).Length -eq 1){
+        # There is only one variable with the same name
+        if ($variablesWithSameName.Scope.Environment -like $variable.Scope.Environment){
+            # The existing variable has the same scope: remove the olkd value
+            $projectVariables.Variables = $projectVariables.Variables | Where-Object { $_.id -notlike $variablesWithSameName.id}
+        }  
+        if ($environmentObj -eq $null){
+            # There is no scope
+            $unscopedVariablesWithSameName = @($variablesWithSameName) | Where-Object { $_.Scope -like $null}
+            $projectVariables.Variables = $projectVariables.Variables | Where-Object { $_.id -notin @($unscopedVariablesWithSameName.id)}
+        } 
+    }
+    if (@($variablesWithSameName.Name).Length -gt 1){
+        Write-output "65" 
+        # There are multiple variables with the same name
+        if (@($variablesWithSameName.Scope.Environment) -contains $variable.Scope.Environment){
+            # At least one of the existing variables is scoped to this environment, removing all with same scope
+            $variablesWithMatchingNameAndScope = $variablesWithSameName | Where-Object { $_.Scope.Environment -like $variable.Scope.Environment}
+            $projectVariables.Variables = $projectVariables.Variables | Where-Object { $_.id -notin @($variablesWithMatchingNameAndScope.id)}
+        }
+        if ($environmentObj -eq $null){
+            # There is no scope
+            $unscopedVariablesWithSameName = $variablesWithSameName | Where-Object { $_.Scope -like $null}
+            $projectVariables.Variables = $projectVariables.Variables | Where-Object { $_.id -notin @($unscopedVariablesWithSameName.id)}
+        }  
+    }
+    
+    # Adding the new value
+    $projectVariables.Variables += $variable
+    
+    # Update the collection
+    Invoke-RestMethod -Method Put -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header -Body ($projectVariables | ConvertTo-Json -Depth 10)
 }
 
-# Check to see if variable is already present
-$variableToUpdate = $projectVariables.Variables | Where-Object {$_.Name -eq $variable.Name}
-
-# If the variable does not exist, create it
-if ($null -eq $variableToUpdate)
-{
-    # Create new object
-    $variableToUpdate = New-Object -TypeName PSObject
-    $variableToUpdate | Add-Member -MemberType NoteProperty -Name "Name" -Value $variable.Name
-    $variableToUpdate | Add-Member -MemberType NoteProperty -Name "Value" -Value $variable.Value
-    $variableToUpdate | Add-Member -MemberType NoteProperty -Name "Type" -Value $variable.Type
-    $variableToUpdate | Add-Member -MemberType NoteProperty -Name "IsSensitive" -Value $variable.IsSensitive
-    $variableToUpdate | Add-Member -MemberType NoteProperty -Name "Scope" -Value $variable.Scope
-
-    # Add to collection
-    $projectVariables.Variables += $variableToUpdate
-
-    $projectVariables.Variables
-}        
-
-# Update the value
-$variableToUpdate.Value = $variable.Value
-$variableToUpdate.Scope = $variable.Scope
-
-# Update the collection
-Invoke-RestMethod -Method Put -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header -Body ($projectVariables | ConvertTo-Json -Depth 10)
+Set-OctopusVariable -octopusURL "https://xxx.octopus.app/" -octopusAPIKey "API-xxx" -projectName "hello_world" -varName "name" -varValue "alex" -environment "Production"

--- a/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
+++ b/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
@@ -2,7 +2,7 @@ function Set-OctopusVariable {
     param(
         $octopusURL = "https://xxx.octopus.app/", # Octopus Server URL
         $octopusAPIKey = "API-xxx",               # API key goes here
-        $projectName = "my_sql_octopus_poc",      # Replace with your project name
+        $projectName = "",                        # Replace with your project name
         $spaceName = "Default",                   # Replace with the name of the space you are working in
         $environment = $null,                     # Replace with the name of the environment you want to scope the variables to
         $varName = "",                            # Replace with the name of the variable

--- a/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
+++ b/REST/PowerShell/Variables/ModifyOrAddVariableToProject.ps1
@@ -41,9 +41,9 @@ function Set-OctopusVariable {
     $variablesWithSameName = $projectVariables.Variables | Where-Object {$_.Name -eq $variable.Name}
 
     if (@($variablesWithSameName.Name).Length -eq 1){
-        # There is only one variable with the same name
+        # There is one variable with the same name
         if ($variablesWithSameName.Scope.Environment -like $variable.Scope.Environment){
-            # The existing variable has the same scope: remove the olkd value
+            # The existing variable has the same scope: remove the old value
             $projectVariables.Variables = $projectVariables.Variables | Where-Object { $_.id -notlike $variablesWithSameName.id}
         }  
         if ($environmentObj -eq $null){
@@ -53,7 +53,6 @@ function Set-OctopusVariable {
         } 
     }
     if (@($variablesWithSameName.Name).Length -gt 1){
-        Write-output "65" 
         # There are multiple variables with the same name
         if (@($variablesWithSameName.Scope.Environment) -contains $variable.Scope.Environment){
             # At least one of the existing variables is scoped to this environment, removing all with same scope


### PR DESCRIPTION
Previous version overwrote all variables with same name (regardless of scope).

For example, suppose existing variables were:

SqlConnectionString (dev): foo
SqlConnectionString (test): bar

And suppose you wanted to add a connection string for prod. Running old script would result in:

SqlConnectionString (prod): baz

Using new version, you would instead end up with 

SqlConnectionString (dev): foo
SqlConnectionString (test): bar
SqlConnectionString (prod): baz

I suspect the latter is what most people are looking for.

Also, formatted the code as a function for simpler re-usability.