### PR TITLE
Add searching of variable sets to FindVariableUsage.ps1

### DIFF
--- a/REST/PowerShell/Variables/FindVariableUsage.ps1
+++ b/REST/PowerShell/Variables/FindVariableUsage.ps1
@@ -39,7 +39,7 @@ foreach ($project in $projects) {
     $projectVariableSet = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header
 
     # Check to see if variable is named in project variables.
-    $matchingNamedVariables = $projectVariableSet.Variables | Where-Object { $_.Name -like "*$variableToFind*" }
+    $matchingNamedVariables = $projectVariableSet.Variables | Where-Object { $_.Name -eq "$variableToFind" }
     if ($null -ne $matchingNamedVariables) {
         foreach ($match in $matchingNamedVariables) {
             $result = [pscustomobject]@{

--- a/REST/PowerShell/Variables/FindVariableUsage.ps1
+++ b/REST/PowerShell/Variables/FindVariableUsage.ps1
@@ -59,7 +59,7 @@ foreach ($project in $projects)
     }
 
     # Check to see if variable is referenced in other project variable values.
-    $matchingValueVariables = $projectVariableSet.Variables | Where-Object {$_.Value -like "*$variableToFind*"}
+    $matchingValueVariables = $projectVariableSet.Variables | Where-Object {$_.Value -like "*#{$variableToFind}*"}
     if($null -ne $matchingValueVariables) {
         foreach($match in $matchingValueVariables) {
             $result = [pscustomobject]@{

--- a/REST/PowerShell/Variables/FindVariableUsage.ps1
+++ b/REST/PowerShell/Variables/FindVariableUsage.ps1
@@ -25,7 +25,7 @@ $variableTracking = @()
 $octopusURL = $octopusURL.TrimEnd('/')
 
 # Get space
-$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}
+$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object { $_.Name -eq $spaceName }
 
 Write-Host "Looking for usages of variable named $variableToFind in space: '$spaceName'"
 
@@ -33,24 +33,23 @@ Write-Host "Looking for usages of variable named $variableToFind in space: '$spa
 $projects = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/projects/all" -Headers $header
 
 # Loop through projects
-foreach ($project in $projects) 
-{
+foreach ($project in $projects) {
     Write-Host "Checking project '$($project.Name)'"
     # Get project variables
     $projectVariableSet = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/variables/$($project.VariableSetId)" -Headers $header
 
     # Check to see if variable is named in project variables.
-    $matchingNamedVariables = $projectVariableSet.Variables | Where-Object {$_.Name -like "*$variableToFind*"}
-    if($null -ne $matchingNamedVariables) {
-        foreach($match in $matchingNamedVariables) {
+    $matchingNamedVariables = $projectVariableSet.Variables | Where-Object { $_.Name -like "*$variableToFind*" }
+    if ($null -ne $matchingNamedVariables) {
+        foreach ($match in $matchingNamedVariables) {
             $result = [pscustomobject]@{
-                Project = $project.Name
-                VariableSet = $null
-                MatchType = "Named Project Variable"
-                Context = $match.Name
-                Property = $null
+                Project           = $project.Name
+                VariableSet       = $null
+                MatchType         = "Named Project Variable"
+                Context           = $match.Name
+                Property          = $null
                 AdditionalContext = $match.Value
-                Link = "$octopusURL$($project.Links.Web)/variables"
+                Link              = "$octopusURL$($project.Links.Web)/variables"
             }
 
             # Add and de-dupe later
@@ -59,17 +58,17 @@ foreach ($project in $projects)
     }
 
     # Check to see if variable is referenced in other project variable values.
-    $matchingValueVariables = $projectVariableSet.Variables | Where-Object {$_.Value -like "*#{$variableToFind}*"}
-    if($null -ne $matchingValueVariables) {
-        foreach($match in $matchingValueVariables) {
+    $matchingValueVariables = $projectVariableSet.Variables | Where-Object { $_.Value -like "*#{$variableToFind}*" }
+    if ($null -ne $matchingValueVariables) {
+        foreach ($match in $matchingValueVariables) {
             $result = [pscustomobject]@{
-                Project = $project.Name
-                VariableSet = $null
-                MatchType = "Referenced Project Variable"
-                Context = $match.Name
-                Property = $null
+                Project           = $project.Name
+                VariableSet       = $null
+                MatchType         = "Referenced Project Variable"
+                Context           = $match.Name
+                Property          = $null
                 AdditionalContext = $match.Value
-                Link = "$octopusURL$($project.Links.Web)/variables"
+                Link              = "$octopusURL$($project.Links.Web)/variables"
             }
             # Add and de-dupe later
             $variableTracking += $result
@@ -77,27 +76,25 @@ foreach ($project in $projects)
     }
 
     # Search Deployment process if enabled
-    if($searchDeploymentProcesses -eq $True) {
+    if ($searchDeploymentProcesses -eq $True) {
         # Get project deployment process
         $deploymentProcess = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/deploymentprocesses/$($project.DeploymentProcessId)" -Headers $header)
 
         # Loop through steps
-        foreach($step in $deploymentProcess.Steps)
-        {
-            $props = $step | Get-Member | Where-Object {$_.MemberType -eq "NoteProperty"}
-            foreach($prop in $props)
-            {
+        foreach ($step in $deploymentProcess.Steps) {
+            $props = $step | Get-Member | Where-Object { $_.MemberType -eq "NoteProperty" }
+            foreach ($prop in $props) {
                 $propName = $prop.Name
                 $json = $step.$propName | ConvertTo-Json -Compress -Depth 10
-                if($null -ne $json -and ($json -like "*$variableToFind*")) {
+                if ($null -ne $json -and ($json -like "*$variableToFind*")) {
                     $result = [pscustomobject]@{
-                        Project = $project.Name
-                        VariableSet = $null
-                        MatchType= "Step"
-                        Context = $step.Name
-                        Property = $propName
+                        Project           = $project.Name
+                        VariableSet       = $null
+                        MatchType         = "Step"
+                        Context           = $step.Name
+                        Property          = $propName
                         AdditionalContext = $null
-                        Link = "$octopusURL$($project.Links.Web)/deployments/process/steps?actionId=$($step.Actions[0].Id)"
+                        Link              = "$octopusURL$($project.Links.Web)/deployments/process/steps?actionId=$($step.Actions[0].Id)"
                     }
                     # Add and de-dupe later
                     $variableTracking += $result
@@ -107,34 +104,31 @@ foreach ($project in $projects)
     }
 
     # Search Runbook processes if enabled
-    if($searchRunbooksProcesses -eq $True) {
+    if ($searchRunbooksProcesses -eq $True) {
 
         # Get project runbooks
         $runbooks = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/projects/$($project.Id)/runbooks?skip=0&take=5000" -Headers $header)
 
         # Loop through each runbook
-        foreach($runbook in $runbooks.Items)
-        {
+        foreach ($runbook in $runbooks.Items) {
             # Get runbook process
             $runbookProcess = (Invoke-RestMethod -Method Get -Uri "$octopusURL$($runbook.Links.RunbookProcesses)" -Headers $header)
 
             # Loop through steps
-            foreach($step in $runbookProcess.Steps)
-            {
-                $props = $step | Get-Member | Where-Object {$_.MemberType -eq "NoteProperty"}
-                foreach($prop in $props)
-                {
+            foreach ($step in $runbookProcess.Steps) {
+                $props = $step | Get-Member | Where-Object { $_.MemberType -eq "NoteProperty" }
+                foreach ($prop in $props) {
                     $propName = $prop.Name
                     $json = $step.$propName | ConvertTo-Json -Compress -Depth 10
-                    if($null -ne $json -and ($json -like "*$variableToFind*")) {
+                    if ($null -ne $json -and ($json -like "*$variableToFind*")) {
                         $result = [pscustomobject]@{
-                            Project = $project.Name
-                            VariableSet  = $null
-                            MatchType = "Runbook Step"
-                            Context = $runbook.Name
-                            Property = $propName
+                            Project           = $project.Name
+                            VariableSet       = $null
+                            MatchType         = "Runbook Step"
+                            Context           = $runbook.Name
+                            Property          = $propName
                             AdditionalContext = $step.Name
-                            Link = "$octopusURL$($project.Links.Web)/operations/runbooks/$($runbook.Id)/process/$($runbook.RunbookProcessId)/steps?actionId=$($step.Actions[0].Id)"
+                            Link              = "$octopusURL$($project.Links.Web)/operations/runbooks/$($runbook.Id)/process/$($runbook.RunbookProcessId)/steps?actionId=$($step.Actions[0].Id)"
                         }
                         # Add and de-dupe later
                         $variableTracking += $result
@@ -150,7 +144,7 @@ $VariableSets = (Invoke-RestMethod -Method Get "$OctopusURL/api/libraryvariables
 foreach ($VariableSet in $VariableSets) {
     Write-Host "Checking Variable Set: $($VariableSet.Name)"
     $variables = (Invoke-RestMethod -Method Get "$OctopusURL/$($VariableSet.Links.Variables)" -Headers $header).Variables | Where-Object { $_.Value -like "*#{$variableToFind}*" }
-    $link = ($VariableSet.Links.Self -replace "/api","app#") -replace "/libraryvariablesets/","/library/variables/"
+    $link = ($VariableSet.Links.Self -replace "/api", "app#") -replace "/libraryvariablesets/", "/library/variables/"
     foreach ($variable in $variables) {
         $result = [pscustomobject]@{
             Project           = $null
@@ -161,6 +155,7 @@ foreach ($VariableSet in $VariableSets) {
             AdditionalContext = $variable.Value
             Link              = "$octopusURL$($link)"
         }
+
         # Add and de-dupe later
         $variableTracking += $result
     }
@@ -169,7 +164,7 @@ foreach ($VariableSet in $VariableSets) {
 # De-dupe
 $variableTracking = @($variableTracking | Sort-Object -Property * -Unique)
 
-if($variableTracking.Count -gt 0) {
+if ($variableTracking.Count -gt 0) {
     Write-Host ""
     Write-Host "Found $($variableTracking.Count) results:"
     $variableTracking


### PR DESCRIPTION
This script was super helpful to me! The one thing I needed it to do that it wasn't was also search variable sets since we sometimes reference variables in the same or other variable sets.  This probably isn't a best practice but it's what we do.  

I also updated the project variable value search to look for explicit references only (`$_.Value -like "*$variableToFind*"` to `$_.Value -like "*#{$variableToFind}*"`).  This was due to the fact that the thing I was searching for (`RedisHost`) was also in the variable name I was replacing this with (`Web.RedisHost`) and was showing false positives.  This also happens in other parts of the search but it would be much more complex to change those to be more explicit. 


Finally, there were also a bunch of formatting changes that VS code applied when I made this change. I put them in a separate commit so it's easier to review the actual changes but I can remove them in needed. 

Thanks for creating this great repo of code examples!