### PR TITLE
Removed property that was causing issues in Run a Script Example

### DIFF
--- a/REST/PowerShell/DeploymentProcesses/CreateScriptStep.ps1
+++ b/REST/PowerShell/DeploymentProcesses/CreateScriptStep.ps1
@@ -46,7 +46,6 @@ $steps += @{
             'Octopus.Action.EnabledFeatures' = ""
             'Octopus.Action.Script.ScriptSource' = "Inline"
             'Octopus.Action.Script.Syntax' = "PowerShell"
-            'Octopus.Action.Script.ScriptFilename' = $null
             'Octopus.Action.Script.ScriptBody' = $scriptBody
         }
         Packages = @()


### PR DESCRIPTION
Removed: 'Octopus.Action.Script.ScriptFilename' = $null

Bad Request when this property is in place