### PR TITLE
Cloning now carries over the EnvironmentScope and RunRetentionPolicy

### DIFF
--- a/Octopus.Client/LINQPad/CloneRunbookAcrossProjects.linq
+++ b/Octopus.Client/LINQPad/CloneRunbookAcrossProjects.linq
@@ -47,6 +47,8 @@ var newRunbook = spaceRepo.Runbooks.Create(new RunbookResource()
 	ProjectId = destinationProject.Id,
 	Name = newRunbookName,
 	Description = newRunbookDescription,
+	EnvironmentScope = runbookToClone.EnvironmentScope,
+	RunRetentionPolicy = runbookToClone.RunRetentionPolicy,
 });
 
 


### PR DESCRIPTION
This LINQPad script did clone the runbook, but I encountered an error in Octopus because the runbook was created with a RunRetentionPolicy of null.  I've added two lines to clone the RunRetentionPolicy and also the EnvironmentScope.