### PR TITLE
Removes an Associated Tenant from an Account

### DIFF
--- a/REST/PowerShell/Accounts/RemoveAssociatedTenantFromAccount.ps1
+++ b/REST/PowerShell/Accounts/RemoveAssociatedTenantFromAccount.ps1
@@ -1,0 +1,25 @@
+﻿$OctopusServerUrl = "https://YOUR_OCTOPUS_URL"  #PUT YOUR SERVER LOCATION HERE. (e.g. http://localhost)
+$ApiKey = "API-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"  #PUT YOUR API KEY HERE
+$SpaceId = "Spaces-XX" # (e.g. Spaces-1)
+$TenantId = "Tenants-XX"  #TenantID to remove (e.g. Tenants-12)
+$AccountId = "Accounts-XX"  #AccountID to modify (e.g. Accounts-213)
+
+$Body = Invoke-RestMethod -Method Get -Uri "$OctopusServerUrl/api/$($SpaceId)/accounts/$($AccountId)" -Headers @{"X-Octopus-ApiKey" = "$ApiKey" }
+
+$NewTenantList = @()
+$Tenants = $Body.TenantIds
+
+Foreach ($Tenant in $Tenants) {
+    Write-Host "$($Tenant)"
+    if ($Tenant -eq $TenantId) {
+        Write-Host "$($TenantId) removed from $($AccountId)"
+    }
+    
+    if ($Tenant -ne $TenantId) {
+        $NewTenantList += $Tenant
+    }
+}
+
+$Body.TenantIds = $NewTenantList
+   
+Invoke-RestMethod -Method PUT -Uri "$OctopusServerUrl/api/$($SpaceId)/accounts/$($AccountId)" -Headers @{"X-Octopus-ApiKey" = "$ApiKey" } -body ($Body | ConvertTo-Json)


### PR DESCRIPTION
A quick way to remove a single Tenant from a list of associated Tenants from an Account. Will not work if you attempt to remove the only associated Tenant from an Account.