### PR TITLE
Fix Offline Machines Count

### DIFF
--- a/REST/PowerShell/Targets/FindUnusedTargets.ps1
+++ b/REST/PowerShell/Targets/FindUnusedTargets.ps1
@@ -119,7 +119,7 @@ function Update-CategorizedMachines
 
         $categorizedMachines.ActiveMachines += 1
 
-        if ($machine.Status -ne "Online")
+        if ($machine.HealthStatus -eq "Unavailable")
         {
             $categorizedMachines.OfflineMachines += $machine            
         }


### PR DESCRIPTION
Offline machine count was checking a JSON field that doesn't exist, resulting in all machines being counted as Offline. Updated to only count machines with the status "Unavailable"