### PR TITLE
Update DrainOddOrEvenOctopusServerNodes.ps1

### DIFF
--- a/REST/PowerShell/Administration/DrainOddOrEvenOctopusServerNodes.ps1
+++ b/REST/PowerShell/Administration/DrainOddOrEvenOctopusServerNodes.ps1
@@ -66,7 +66,7 @@ for ($i = 0; $i -lt $octopusServerNodes.Length; $i++) {
         if ($global:WhatIf -eq $False) {
             $body = @{
                 Id                  = $octopusServerNode.Id
-                Name                = $octopusServerNode.MaxConcurrentTasks
+                Name                = $octopusServerNode.Name
                 MaxConcurrentTasks  = $octopusServerNode.MaxConcurrentTasks
                 IsInMaintenanceMode = $true
             }


### PR DESCRIPTION
Updated line 69 from $octopusServerNode.MaxConcurrentTasks to $octopusServerNode.Name - otherwise it renames the targeted HA nodes, whoops! <blush>