### PR TITLE
Update GetStepsUsingWorkerPool.ps1

### DIFF
--- a/REST/PowerShell/DeploymentProcesses/GetStepsUsingWorkerPool.ps1
+++ b/REST/PowerShell/DeploymentProcesses/GetStepsUsingWorkerPool.ps1
@@ -21,7 +21,7 @@ $projectList = Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/
 # Loop through projects
 foreach ($project in $projectList) {
     
-    $runbooksListLink = "/api/$($space.Id)/projects/$($project.Id)/runbooks/all"
+    $runbooksListLink = "/api/$($space.Id)/projects/$($project.Id)/runbooks/all/v2"
     $runbooksList = Invoke-RestMethod -Method Get -Uri "$octopusURL$runbooksListLink" -Headers $header
 
     # Loop through runbooks


### PR DESCRIPTION
The API endpoint api/projects/{projectId}/runbooks/all is deprecated. Please see https://oc.to/deprecation-allrunbooksv1 for more details.

Replaced with v2.