### PR TITLE
Update GetUsageCounts.ps1

### DIFF
--- a/REST/PowerShell/Administration/GetUsageCounts.ps1
+++ b/REST/PowerShell/Administration/GetUsageCounts.ps1
@@ -566,10 +566,10 @@ Write-Host "The item counts are as follows:"
 Write-Host "    Instance ID: $($apiInformation.InstallationId)"
 Write-Host "    Server Version: $($apiInformation.Version)"
 Write-Host "    Number of Server Nodes: $($nodeInfo.TotalResults)"
-Write-Host "    Licensed Target Count: $($ObjectCounts.LicensedTargetCount) (these are active targets de-duped across the instance if running a modern version of Octopus)" -ForegroundColor Green
+Write-Host "    Licensed Machine Count: $($ObjectCounts.LicensedTargetCount) (these are active targets de-duped across the instance if running a modern version of Octopus)" -ForegroundColor Green
 Write-Host "    Project Count: $($ObjectCounts.ProjectCount)"
 Write-Host "    Tenant Count: $($ObjectCounts.TenantCount)" 
-Write-Host "    Machine Counts (Active Linux and Windows Tentacles and SSH Connections): $($ObjectCounts.WindowsLinuxMachineCount)" 
+Write-Host "    Total Machine Count (Active Linux and Windows Tentacles and SSH Connections): $($ObjectCounts.WindowsLinuxMachineCount)" 
 Write-Host "    Deployment Target Count: $($ObjectCounts.TargetCount)"
 Write-Host "        Active and Available Targets: $($ObjectCounts.ActiveTargetCount)" -ForegroundColor Green
 Write-Host "        Active but Unavailable Targets: $($ObjectCounts.UnavailableTargetCount)" -ForegroundColor Yellow


### PR DESCRIPTION
Proposing reword 'Licensed Target Count' to 'Licensed Machine Count' and changing 'Machine counts' to 'Total Machine Count.' 

A customer who is moving to PTM was confused. They thought we were not correctly de-duplicating targets across spaces. They thought their quote would be based on the much higher 'Total Machine Count' value, not the 'Licensed Machine Count.'