### PR TITLE
Fix broken syntax and array/string logic

### DIFF
--- a/REST/PowerShell/Tasks/RunHealthCheck.ps1
+++ b/REST/PowerShell/Tasks/RunHealthCheck.ps1
@@ -24,6 +24,10 @@ if (-not [string]::IsNullOrWhiteSpace($EnvironmentName))
     $EnvironmentID = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/environments/all" -Headers $header) |
         Where-Object { $_.Name -eq $EnvironmentName } |
         Select-Object -ExpandProperty Id -First 1
+    if (-not $EnvironmentID)
+    {
+        throw "Environment '$EnvironmentName' not found in space '$($space.Name)'"
+    }
 }
 
 # Get MachineIds
@@ -33,6 +37,10 @@ if ($MachineNames.Count -gt 0)
     $MachineIds = @((Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines/all" -Headers $header) |
         Where-Object { $MachineNames -contains $_.Name } |
         Select-Object -ExpandProperty Id)
+    if ($MachineIds.Count -ne $MachineNames.Count)
+    {
+        throw "One or more machines not found in space '$($space.Name)'"
+    }
 }
 
 # Create json payload

--- a/REST/PowerShell/Tasks/RunHealthCheck.ps1
+++ b/REST/PowerShell/Tasks/RunHealthCheck.ps1
@@ -15,48 +15,43 @@ $MachineNames = @() # Leave blank to check all machines
 
 # Get space
 $space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) |
-    Where-Object { $_.Name -eq $spaceName }
-if (-not $space)
-{
+Where-Object { $_.Name -eq $spaceName }
+if (-not $space) {
     throw "Space '$spaceName' not found"
 }
 
 # Get EnvironmentId
 $EnvironmentID = $null
-if (-not [string]::IsNullOrWhiteSpace($EnvironmentName))
-{
+if (-not [string]::IsNullOrWhiteSpace($EnvironmentName)) {
     $EnvironmentID = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/environments/all" -Headers $header) |
-        Where-Object { $_.Name -eq $EnvironmentName } |
-        Select-Object -ExpandProperty Id -First 1
-    if (-not $EnvironmentID)
-    {
+    Where-Object { $_.Name -eq $EnvironmentName } |
+    Select-Object -ExpandProperty Id -First 1
+    if (-not $EnvironmentID) {
         throw "Environment '$EnvironmentName' not found in space '$($space.Name)'"
     }
 }
 
 # Get MachineIds
 $MachineIds = @()
-if ($MachineNames.Count -gt 0)
-{
+if ($MachineNames.Count -gt 0) {
     $MachineIds = @((Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines/all" -Headers $header) |
         Where-Object { $MachineNames -contains $_.Name } |
         Select-Object -ExpandProperty Id)
-    if ($MachineIds.Count -ne $MachineNames.Count)
-    {
+    if ($MachineIds.Count -ne $MachineNames.Count) {
         throw "One or more machines not found in space '$($space.Name)'"
     }
 }
 
 # Create json payload
 $jsonPayload = @{
-    SpaceId = "$($space.Id)"
-    Name = "Health"
+    SpaceId     = "$($space.Id)"
+    Name        = "Health"
     Description = $Description
-    Arguments = @{
-        Timeout = "$([TimeSpan]::FromMinutes($TimeOutAfterMinutes))"
+    Arguments   = @{
+        Timeout        = "$([TimeSpan]::FromMinutes($TimeOutAfterMinutes))"
         MachineTimeout = "$([TimeSpan]::FromMinutes($MachineTimeoutAfterMinutes))"
-        EnvironmentId = $EnvironmentID
-        MachineIds = $MachineIds
+        EnvironmentId  = $EnvironmentID
+        MachineIds     = $MachineIds
     }
 }
 

--- a/REST/PowerShell/Tasks/RunHealthCheck.ps1
+++ b/REST/PowerShell/Tasks/RunHealthCheck.ps1
@@ -16,6 +16,10 @@ $MachineNames = @() # Leave blank to check all machines
 # Get space
 $space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) |
     Where-Object { $_.Name -eq $spaceName }
+if (-not $space)
+{
+    throw "Space '$spaceName' not found"
+}
 
 # Get EnvironmentId
 $EnvironmentID = $null

--- a/REST/PowerShell/Tasks/RunHealthCheck.ps1
+++ b/REST/PowerShell/Tasks/RunHealthCheck.ps1
@@ -10,24 +10,29 @@ $TimeOutAfterMinutes = 5
 $MachineTimeoutAfterMinutes = 5
 
 # Choose an Environment, a set of machine names, or both.
-$EnvironmentName = "Development"
-$MachineNames = @()
+$EnvironmentName = "Development" # Leave blank to check all environments
+$MachineNames = @() # Leave blank to check all machines
 
 # Get space
-$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) | Where-Object {$_.Name -eq $spaceName}
+$space = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/spaces/all" -Headers $header) |
+    Where-Object { $_.Name -eq $spaceName }
 
 # Get EnvironmentId
 $EnvironmentID = $null
-if([string]::IsNullOrWhiteSpace($EnvironmentName) -eq $False) 
+if (-not [string]::IsNullOrWhiteSpace($EnvironmentName))
 {
-    $EnvironmentID += (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/environments/all" -Headers $header) | Where-Object {$_.Name -eq $EnvironmentName} | Select-Object -ExpandProperty Id -First 1
+    $EnvironmentID = (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/environments/all" -Headers $header) |
+        Where-Object { $_.Name -eq $EnvironmentName } |
+        Select-Object -ExpandProperty Id -First 1
 }
 
-# Get MachineIds
-$MachineIds = $null
-if($MachineNames.Count -gt 0)
+# Get MachineIds (kept as an array for the JSON payload)
+$MachineIds = @()
+if ($MachineNames.Count -gt 0)
 {
-    $MachineIds = $EnvironmentID += (Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines/all" -Headers $header) | Where-Object {$_.Name -eq $EnvironmentName} | Select-Object -ExpandProperty Id -Join ", "
+    $MachineIds = @((Invoke-RestMethod -Method Get -Uri "$octopusURL/api/$($space.Id)/machines/all" -Headers $header) |
+        Where-Object { $MachineNames -contains $_.Name } |
+        Select-Object -ExpandProperty Id)
 }
 
 # Create json payload

--- a/REST/PowerShell/Tasks/RunHealthCheck.ps1
+++ b/REST/PowerShell/Tasks/RunHealthCheck.ps1
@@ -26,7 +26,7 @@ if (-not [string]::IsNullOrWhiteSpace($EnvironmentName))
         Select-Object -ExpandProperty Id -First 1
 }
 
-# Get MachineIds (kept as an array for the JSON payload)
+# Get MachineIds
 $MachineIds = @()
 if ($MachineNames.Count -gt 0)
 {


### PR DESCRIPTION
Fixing PS error with `Select-Object` and array/string logic.

**Before:**

```
PS C:\Users\User\MyGitRepos\OctopusApiScripts> . 'C:\Users\User\MyGitRepos\OctopusApiScripts\RunHealthCheckForMachines.ps1'
Select-Object: C:\Users\User\MyGitRepos\OctopusApiScripts\RunHealthCheckForMachines.ps1:30:216
Line |
  30 |  … e -eq $EnvironmentName} | Select-Object -ExpandProperty Id -Join ", "
     |                                                               ~~~~~
     | A parameter cannot be found that matches parameter name 'Join'.
```

```
PS C:\Users\User\MyGitRepos\OctopusApiScripts> . 'C:\Users\User\MyGitRepos\OctopusApiScripts\RunHealthCheckForMachines.ps1'
Invoke-RestMethod: C:\Users\User\MyGitRepos\OctopusApiScripts\RunHealthCheckForMachines.ps1:58:1              
Line |
  58 |  Invoke-RestMethod -Method Post -Uri "$octopusURL/api/$($space.Id)/tas …
     |  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     |  {   "ErrorMessage": "There was a problem with your request.",   "Errors": [     "Expected an array but received String"   ],   "ParsedHelpLinks": [],   "Details": {} }
```

**After:**

```
PS C:\Users\User\MyGitRepos\OctopusApiScripts> . 'C:\Users\User\MyGitRepos\OctopusApiScripts\RunHealthCheckForMachines.ps1'

Id                                     : ServerTasks-1818
SpaceId                                : Spaces-1
EstimatedRemainingQueueDurationSeconds : 0
Name                                   : Health
Description                            : Health check started from PowerShell script
Arguments                              : @{MachineTimeout=00:05:00; EnvironmentId=Environments-1; MachineIds=System.Object[]; Timeout=00:05:00}
State                                  : Queued
Completed                              : Queued...
QueueTime                              : 7/28/2026 10:55:43 AM
QueueTimeExpiry                        : 
StartTime                              : 
LastUpdatedTime                        : 7/28/2026 10:55:43 AM
CompletedTime                          : 
ServerNode                             : 
Duration                               : less than a second
ErrorMessage                           : 
HasBeenPickedUpByProcessor             : False
IsCompleted                            : False
FinishedSuccessfully                   : False
HasPendingInterruptions                : False
CanRerun                               : True
HasWarningsOrErrors                    : False
UnmetPreconditions                     : 
ProjectId                              : 
PendingInterruptionTypes               : {}
Links                                  : @{Self=/api/tasks/ServerTasks-1818; Web=/app#/Spaces-1/tasks/ServerTasks-1818; Raw=/api/tasks/ServerTasks-1818/raw; Rerun=/api/tasks/rerun/ServerTasks-1818; Cancel=/api/tasks/ServerTasks-1818/cancel; State=/api/tasks/ServerTasks-1818/state; 
                                         BlockedBy=/api/tasks/ServerTasks-1818/blockedby; QueuedBehind=/api/tasks/ServerTasks-1818/queued-behind{?skip,take}; Details=/api/tasks/ServerTasks-1818/details{?verbose,tail,ranges}; StatusMessages=/api/tasks/ServerTasks-1818/status/messages; 
                                         Prioritize=/api/tasks/ServerTasks-1818/prioritize; Artifacts=/api/Spaces-1/artifacts?regarding=ServerTasks-1818; Interruptions=/api/Spaces-1/interruptions?regarding=ServerTasks-1818}
```